### PR TITLE
Added Multi-Lingual XML metadata schema files

### DIFF
--- a/multi-lingual/schema/multi-lingual-ua-metadata.xsd
+++ b/multi-lingual/schema/multi-lingual-ua-metadata.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A simple metadata schema for a single top-level entity called "lingual" which contains two string entities, title -->
+<!-- and description. Each of these has a "lang" attribute indicating the natural language used for the metadata value -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ml="http://www.preservica.com/example/multi-lingual-ua-metadata/v1"
+           targetNamespace="http://www.preservica.com/example/multi-lingual-ua-metadata/v1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <!-- Base element -->
+    <xs:element name="lingual" type="ml:multiLingualType" />
+
+    <!-- Base element type -->
+    <xs:complexType name="multiLingualType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="title" type="ml:stringType" />
+            <xs:element name="description" type="ml:stringType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <!-- String type with attribute called "lang" -->
+    <xs:complexType name="stringType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="lang" type="xs:string" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/multi-lingual/ua-cmis-xslt/multi-lingual-ua-transform.xslt
+++ b/multi-lingual/ua-cmis-xslt/multi-lingual-ua-transform.xslt
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- A basic stylesheet for generating a UA display of metadata in the multi-lingual schema. -->
+<!-- This uses the "lang" attribute of each metadata element to determine what to display in the item's "name" field. -->
+<!-- This only has French translations, and will default to English text if the lang attribute is missing or set to -->
+<!-- something other than 'fr'. This can be extended to other languages by providing new xsl:when elements following the -->
+<!-- established pattern. -->
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ml="http://www.preservica.com/example/multi-lingual-ua-metadata/v1"
+    xmlns="http://www.tessella.com/sdb/cmis/metadata"
+    exclude-result-prefixes="ml">
+
+    <xsl:output method='xml' indent='yes'/>
+
+    <!-- Match the base element and create a group. Note that the title for this group is hard-coded in English. -->
+    <xsl:template match="ml:lingual">
+        <group>
+            <title>Multi Lingual Metadata</title>
+            <xsl:apply-templates />
+        </group>
+    </xsl:template>
+
+    <!-- Match the title element -->
+    <xsl:template match="ml:title">
+        <item>
+            <!-- For the name, test whether the lang attribute is set to 'fr', and if so use some French text, otherwise, default to English -->
+            <name>
+                <xsl:choose>
+                    <xsl:when test="@lang='fr'">Titre en Français</xsl:when>
+                    <xsl:otherwise>English Title</xsl:otherwise>
+                </xsl:choose>
+            </name>
+            <value>
+                <xsl:value-of select="."/>
+            </value>
+            <type>
+                <xsl:value-of select="concat('ml.ml_', local-name())"/>
+            </type>
+        </item>
+    </xsl:template>
+
+    <!-- Match the description element -->
+    <xsl:template match="ml:description">
+        <item>
+            <!-- For the name, test whether the lang attribute is set to 'fr', and if so use some French text, otherwise, default to English -->
+            <name>
+                <xsl:choose>
+                    <xsl:when test="@lang='fr'">Description en Français</xsl:when>
+                    <xsl:otherwise>English Description</xsl:otherwise>
+                </xsl:choose>
+            </name>
+            <value>
+                <xsl:value-of select="."/>
+            </value>
+            <type>
+                <xsl:value-of select="concat('ml.ml_', local-name())"/>
+            </type>
+        </item>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/multi-lingual/xml-fragment-template/multi-lingual-template.xml
+++ b/multi-lingual/xml-fragment-template/multi-lingual-template.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- A basic template illustrating usage -->
+<ml:lingual xmlns:ml="http://www.preservica.com/example/multi-lingual-ua-metadata/v1">
+    <ml:title lang="en">The title is in English</ml:title>
+    <ml:description lang="fr">Cette description est en Français</ml:description>
+</ml:lingual>


### PR DESCRIPTION
This includes a basic schema which allows a language attribute to be set on each element and a UA transform that uses that attribute to determine what "name" to show in the metadata block.